### PR TITLE
Removes the zero-length block problem 

### DIFF
--- a/kdb/fileutil.py
+++ b/kdb/fileutil.py
@@ -656,7 +656,9 @@ class KDBWriter:
             #logger.debug("Line:\n{0}Size in bytes: {1}".format(newline, size))
             if size > 65534:
                 self.filehandle._write_block(bgzf._as_bytes(text)) # should this be _write_block?
-                self.filehandle.flush()
+                self.filehandle._buffer = b""
+                self.filehandle._handle.flush()
+                #self.filehandle.flush()
                 text = ''
                 size = 0
             text += newline
@@ -666,7 +668,10 @@ class KDBWriter:
             sys.stderr.write("Wrote {} lines to the file...\n".format(i))
             logger.info("Writing final block...")
             self.filehandle._write_block(bgzf._as_bytes(text))
-            self.filehandle.flush()
+            self.filehandle._buffer = b""
+            self.filehandle._handle.flush()
+
+            #self.filehandle.flush()
 
         if i != self.kdb.num_kmers:
             raise IOError("Wrote {0} lines (of {1} k-mers) to the file...".format(i, self.kdb.num_kmers))

--- a/kdb/index.py
+++ b/kdb/index.py
@@ -2,6 +2,7 @@ import sys
 import os
 import copy
 import json
+import time
 
 import jsonschema
 from Bio import bgzf
@@ -36,34 +37,40 @@ class IndexBuilder:
             offsets = copy.deepcopy(self.kdbrdr._offsets)
             # Omit the header block
             offsets.pop(0)
+            # FIXME
+            offsets.pop(0)
             i = 0 # Block index
             j = 0 # k-mer  index
-            for raw_start, raw_length, data_start, data_length in offsets:
-                if data_length > 0: # If the block is not empty, make a virtual offset
-                    ######      Build+go offset
-                    offset = bgzf.make_virtual_offset(raw_start, 0) # Find the offset of that block
-                    self.kdbrdr._bgzfrdr.seek(offset)       # Seek the start of the block
-                    ######      
-                    line = self.kdbrdr._bgzfrdr.readline()  # Read the first line from the block
-                    while line != '': #and json.loads(line.split("\t")[2]):
-                        #result.append((j, i, raw_start, offset))       # Push (k-mer, block, block_offset, offset) onto the stack
-                        result.append((j, offset))
-                        ######  Build+go offset
-                        offset = self.kdbrdr._bgzfrdr.tell()# Find the offset of the next line
-                        self.kdbrdr._bgzfrdr.seek(offset)   # Seek the next line
-                        ######  
-                        line = self.kdbrdr._bgzfrdr.readline() # Read a new line
-                        j += 1                              # Increment the k-mer/line index
+            body_start, block1_length, block1_data_start, block1_data_length = offsets.pop(0)
+            offset = None
+            if block1_data_length > 0: # If the block is not empty, make a virtual offset
+                ######      Build+go offset
+                offset = bgzf.make_virtual_offset(body_start, 0) # Find the offset of that block
+                self.kdbrdr._bgzfrdr.seek(offset)       # Seek the start of the block
+                ######      
+                line = self.kdbrdr._bgzfrdr.readline().rstrip()  # Read the first line from the block
+                while len(line) > 0: #and json.loads(line.split("\t")[2]):
+                    #result.append((j, i, raw_start, offset))       # Push (k-mer, block, block_offset, offset) onto the stack
+                    #print(i, j, line.rstrip().split("\t")[0:2])
+                    #time.sleep(0.5)
+                    result.append((j, offset))
+                    ######  Build+go offset
+                    offset = self.kdbrdr._bgzfrdr.tell()# Find the offset of the next line
+                    self.kdbrdr._bgzfrdr.seek(offset)   # Seek the next line
+                    ######  
+                    line = self.kdbrdr._bgzfrdr.readline().rstrip() # Read a new line
+                    j += 1                              # Increment the k-mer/line index
                 # If the block and/or the emitted line is empty, skip the block
-                    if line == '':
-                        logger.debug("Done with block {}...".format(i))
-                else:
-                    logger.warning("Block {0} starting at {1} has 0 data length".format(i, raw_start))
-                i += 1 # Increment the block counter
+                if len(line) == 0:
+                    logger.debug("\n\nBlock:   {}\nK-mers:   {}".format(i, j))
+            else:
+                logger.warning("Block {0} starting at {1} has 0 data length".format(i, offset))
+                logger.warning("kdb has read {0} k-mers until this point at block {1}".format(j, i))
+            i += 1 # Increment the block counter
             # Verify that the number of indexed lines is equal to the number of theoretical k-mers
             if len(result) != self.kdb.num_kmers: 
                 logger.error("kdb.index.IndexBuilder encountered a fatal bug: a mismatch of the number of indexed lines and the number of theoretical {}-mers".format(self.kdb.k))
-                raise Exception("kdb.index.IndexBuilder.index_lines generated {0} line offsets for {1} k-mers")
+                raise Exception("kdb.index.IndexBuilder.index_lines generated {0} lines offsets for {1} k-mers".format(len(result), self.kdb.num_kmers))
 
         return tuple(result)
             


### PR DESCRIPTION
Largely fixes the zero-length block issue. Ugly hotfix. The `while` loop has been removed from `index.py` and manual flushing added to `kdb.fileutil.KDBWriter`. An exception to the fix is the zero-length block following the header block. The associated line has been marked for followup with a 'FIXME' comment.

fixes #1.